### PR TITLE
fix: correct local API URL to include /api path

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 # Development environment variables
-VITE_API_URL=http://localhost:3000
+VITE_API_URL=http://localhost:3000/api
 VITE_APP_NAME=TeamTime
 VITE_APP_VERSION=1.0.0


### PR DESCRIPTION
- Updated local development API URL from http://localhost:3000 to http://localhost:3000/api
- Backend serves API under /api prefix
- This fixes local development API connection issues